### PR TITLE
Remove pizza from order confirmation popup changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/bin/Debug/net7.0/BlazingPizza.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "BlazingPizza.sln"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/BlazingPizza.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/BlazingPizza.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/BlazingPizza.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -3,6 +3,8 @@
 @inject HttpClient HttpClient
 @inject NavigationManager NavigationManager
 @inject OrderState OrderState
+@inject OrderState OrderState
+@inject IJSRuntime JavaScript
 
 <div class="main">
     <ul class="pizza-cards">

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -11,14 +11,14 @@
         @foreach (var special in specials ?? new())
 
         {
-                <li @onclick="@(() => OrderState.ShowConfigurePizzaDialog(special))"
-                    style="background-image: url('@special.ImageUrl')">
-                    <div class="pizza-info">
-                        <span class="title">@special.Name</span>
+            <li @onclick="@(() => OrderState.ShowConfigurePizzaDialog(special))"
+                style="background-image: url('@special.ImageUrl')">
+                <div class="pizza-info">
+                    <span class="title">@special.Name</span>
                     @special.Description
-                        <span class="price">@special.GetFormattedBasePrice()</span>
-                    </div>
-                </li>
+                    <span class="price">@special.GetFormattedBasePrice()</span>
+                </div>
+            </li>
         }
     </ul>
 </div>
@@ -26,37 +26,37 @@
 @if (OrderState.ShowingConfigureDialog)
 
 {
-        <ConfigurePizzaDialog Pizza="OrderState.ConfiguringPizza" OnCancel="OrderState.CancelConfigurePizzaDialog"
-            OnConfirm="OrderState.ConfirmConfigurePizzaDialog" />
- }   
+    <ConfigurePizzaDialog Pizza="OrderState.ConfiguringPizza" OnCancel="OrderState.CancelConfigurePizzaDialog"
+        OnConfirm="OrderState.ConfirmConfigurePizzaDialog" />
+}
 
 <div class="sidebar @(order.Pizzas.Any() ? "with-total" : "")">
     @if (order.Pizzas.Any())
     {
 
         <div class="order-contents">
-                <h2>Your order</h2>
-    
+            <h2>Your order</h2>
+
             @foreach (var configuredPizza in order.Pizzas)
             {
 
                 <div class="cart-item">
-                            <button type="button" class="close text-danger" aria-label="Close"
-                            @onclick="@(async () => await RemovePizzaConfirmation(configuredPizza))">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                            <div class="title">@(configuredPizza.Size)" @configuredPizza.Special!.Name</div>
+                    <button type="button" class="close text-danger" aria-label="Close"
+                    @onclick="@(async () => await RemovePizzaConfirmation(configuredPizza))">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                    <div class="title">@(configuredPizza.Size)" @configuredPizza.Special!.Name</div>
                     <div class="item-price">
-                                @configuredPizza.GetFormattedTotalPrice()
-                            </div>
+                        @configuredPizza.GetFormattedTotalPrice()
+                    </div>
                 </div>
-                }
-     
-   </div>
+            }
+
+        </div>
     }
 
     else
-       { 
+    {
         <div class="empty-cart">Choose a pizza<br>to get started</div>
     }
 
@@ -84,12 +84,23 @@
     $"{NavigationManager.BaseUri}specials");
 
     async Task RemovePizzaConfirmation(Pizza removePizza)
-{
-    if (await JavaScript.InvokeAsync<bool>(
-        "confirm",
-        $"""Do you want to remove the "{removePizza.Special!.Name}" from your order?"""))
     {
-        OrderState.RemoveConfiguredPizza(removePizza);
+        var messageParams = new
+        {
+            title = "Remove Pizza?",
+            text = $"""Do you want to remove the "{removePizza.Special!.Name}" from your order?""",
+            icon = "warning",
+            buttons = new
+            {
+                abort = new { text = "No, leave it in my order", value = false },
+                confirm = new { text = "Yes, remove pizza", value = true }
+            },
+            dangerMode = true
+        };
+
+        if (await JavaScript.InvokeAsync<bool>("swal", messageParams))
+        {
+            OrderState.RemoveConfiguredPizza(removePizza);
+        }
     }
-}
 }

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -9,64 +9,87 @@
 <div class="main">
     <ul class="pizza-cards">
         @foreach (var special in specials ?? new())
+
         {
-            <li @onclick="@(() => OrderState.ShowConfigurePizzaDialog(special))" 
-                style="background-image: url('@special.ImageUrl')">
-                <div class="pizza-info">
-                    <span class="title">@special.Name</span>
+                <li @onclick="@(() => OrderState.ShowConfigurePizzaDialog(special))"
+                    style="background-image: url('@special.ImageUrl')">
+                    <div class="pizza-info">
+                        <span class="title">@special.Name</span>
                     @special.Description
-                    <span class="price">@special.GetFormattedBasePrice()</span>
-                </div>
-            </li>
+                        <span class="price">@special.GetFormattedBasePrice()</span>
+                    </div>
+                </li>
         }
     </ul>
 </div>
 
 @if (OrderState.ShowingConfigureDialog)
+
 {
-    <ConfigurePizzaDialog Pizza="OrderState.ConfiguringPizza"
-        OnCancel="OrderState.CancelConfigurePizzaDialog"
-        OnConfirm="OrderState.ConfirmConfigurePizzaDialog" />
-}
+        <ConfigurePizzaDialog Pizza="OrderState.ConfiguringPizza" OnCancel="OrderState.CancelConfigurePizzaDialog"
+            OnConfirm="OrderState.ConfirmConfigurePizzaDialog" />
+ }   
 
 <div class="sidebar @(order.Pizzas.Any() ? "with-total" : "")">
     @if (order.Pizzas.Any())
     {
-        <div class="order-contents">
-            <h2>Your order</h2>
 
+        <div class="order-contents">
+                <h2>Your order</h2>
+    
             @foreach (var configuredPizza in order.Pizzas)
             {
+
                 <div class="cart-item">
-                    <a @onclick="@(() => OrderState.RemoveConfiguredPizza(configuredPizza))" 
-                        class="delete-item">❌</a>
-                    <div class="title">@(configuredPizza.Size)" @configuredPizza.Special!.Name</div>
+                            <button type="button" class="close text-danger" aria-label="Close"
+                            @onclick="@(async () => await RemovePizzaConfirmation(configuredPizza))">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                            <div class="title">@(configuredPizza.Size)" @configuredPizza.Special!.Name</div>
                     <div class="item-price">
-                        @configuredPizza.GetFormattedTotalPrice()
-                    </div>
+                                @configuredPizza.GetFormattedTotalPrice()
+                            </div>
                 </div>
-            }
-        </div>
+                }
+     
+   </div>
     }
+
     else
-    {
+       { 
         <div class="empty-cart">Choose a pizza<br>to get started</div>
     }
 
     <div class="order-total @(order.Pizzas.Any() ? "" : "hidden")">
         Total:
         <span class="total-price">@order.GetFormattedTotalPrice()</span>
-        <a href="checkout" class="@(OrderState.Order.Pizzas.Count is 0 ? "btn btn-warning disabled" : "btn btn-warning")">
+        <a href="checkout"
+            class="@(OrderState.Order.Pizzas.Count is 0 ? "btn btn-warning disabled" : "btn btn-warning")">
             Order >
         </a>
     </div>
 </div>
 
+
 @code {
+
+
     List<PizzaSpecial>? specials = new();
     Order order => OrderState.Order;
 
-    protected override async Task OnInitializedAsync() => 
-        specials = await HttpClient.GetFromJsonAsync<List<PizzaSpecial>>(
-            $"{NavigationManager.BaseUri}specials");
+
+
+    protected override async Task OnInitializedAsync() =>
+    specials = await HttpClient.GetFromJsonAsync<List<PizzaSpecial>>(
+    $"{NavigationManager.BaseUri}specials");
+
+    async Task RemovePizzaConfirmation(Pizza removePizza)
+{
+    if (await JavaScript.InvokeAsync<bool>(
+        "confirm",
+        $"""Do you want to remove the "{removePizza.Special!.Name}" from your order?"""))
+    {
+        OrderState.RemoveConfiguredPizza(removePizza);
+    }
+}
 }

--- a/Pages/_Host.cshtml
+++ b/Pages/_Host.cshtml
@@ -5,6 +5,7 @@
 
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -12,9 +13,10 @@
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" asp-append-version="true" />
     <link href="BlazingPizza.styles.css" rel="stylesheet" />
-    <link rel="icon" type="image/png" href="favicon.png"/>
+    <link rel="icon" type="image/png" href="favicon.png" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
+
 <body>
     <component type="typeof(App)" render-mode="ServerPrerendered" />
 
@@ -30,5 +32,7 @@
     </div>
 
     <script src="_framework/blazor.server.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert@latest/dist/sweetalert.min.js"></script>
 </body>
+
 </html>


### PR DESCRIPTION
When a customer adds a pizza to their order, they can select a X to remove it without confirmation. The company thinks customers might have been accidentally clicking this and removing items from their order. 

The pizza company feels that their customers could be confused by the word cancel in the popup. They'd like the text on the buttons to be clearer. Also, they don't like how their existing branding and styling aren't used.

After some research, I've found a small JavaScript library called SweetAlert that looks like a good replacement.